### PR TITLE
Add minimal Docker setup and make Bun optional with npm fallback

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,5 +33,13 @@ jobs:
           echo "Pages deployment timed out"
           exit 1
 
-      - name: Test remote install
+      - name: Test remote install (with Homebrew)
         run: make docker-test-remote
+
+  minimal-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test setup without Homebrew
+        run: make docker-test-minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ USER linuxbrew
 ENV HOME=/home/linuxbrew
 
 # Copy dotfiles
-COPY --chown=linuxbrew:linuxbrew . ${HOME}/dotfiles
-WORKDIR ${HOME}/dotfiles
+COPY --chown=linuxbrew:linuxbrew . ${HOME}/.dotfiles
+WORKDIR ${HOME}/.dotfiles
 
 # Make entrypoint executable
 RUN chmod +x scripts/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,6 @@ RUN apt-get update -qq && \
 USER linuxbrew
 ENV HOME=/home/linuxbrew
 
-# Install Bun for testing Claude Code plugin
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="${HOME}/.bun/bin:${PATH}"
-
 # Copy dotfiles
 COPY --chown=linuxbrew:linuxbrew . ${HOME}/dotfiles
 WORKDIR ${HOME}/dotfiles

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -18,9 +18,12 @@ USER testuser
 ENV HOME=/home/testuser
 WORKDIR ${HOME}
 
+# Prevent zsh new user wizard
+RUN touch ~/.zshrc
+
 # Copy dotfiles
-COPY --chown=testuser:testuser . ${HOME}/dotfiles
-WORKDIR ${HOME}/dotfiles
+COPY --chown=testuser:testuser . ${HOME}/.dotfiles
+WORKDIR ${HOME}/.dotfiles
 
 # Make entrypoint executable
 RUN chmod +x scripts/docker-entrypoint.sh

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install only base packages (no Homebrew)
 RUN apt-get update -qq && \
-  apt-get install -y curl git stow vim locales zsh python3 && \
+  apt-get install -y curl git stow vim locales zsh && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   localedef -i en_GB -f UTF-8 en_GB.UTF-8

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,29 @@
+# Minimal test environment without Homebrew
+# Tests the fallback path when brew is not available
+FROM ubuntu:24.04
+
+ENV TERM=xterm-256color
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only base packages (no Homebrew)
+RUN apt-get update -qq && \
+  apt-get install -y curl git stow vim locales zsh python3 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  localedef -i en_GB -f UTF-8 en_GB.UTF-8
+
+# Create test user
+RUN useradd -m -s /bin/zsh testuser
+USER testuser
+ENV HOME=/home/testuser
+WORKDIR ${HOME}
+
+# Copy dotfiles
+COPY --chown=testuser:testuser . ${HOME}/dotfiles
+WORKDIR ${HOME}/dotfiles
+
+# Make entrypoint executable
+RUN chmod +x scripts/docker-entrypoint.sh
+
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
+CMD ["shell"]

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ docker-setup: docker-build ## Run setup and drop into shell (use VARIANT=minimal
 	docker run -it --rm $(IMAGE) setup$(CMD_SUFFIX)
 
 docker-clean: ## Remove persistent Docker containers
-	docker rm -f $(CONTAINER_NAME) 2>/dev/null || true
-	docker rm -f $(CONTAINER_NAME)-minimal 2>/dev/null || true
+	docker rm -f $(CONTAINER_NAME) $(CONTAINER_NAME)-minimal 2>/dev/null || true
 
 docker-test-remote: ## Smoke test remote install from deployed URL
 	docker build -f Dockerfile.remote-test -t $(IMAGE_NAME)-remote .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 IMAGE_NAME := dotfiles
 CONTAINER_NAME := dotfiles-dev
 
+# VARIANT support: use VARIANT=minimal for minimal image
+# e.g., make docker-build VARIANT=minimal
+VARIANT ?=
+DOCKERFILE := Dockerfile$(if $(VARIANT),.$(VARIANT))
+IMAGE := $(IMAGE_NAME)$(if $(VARIANT),-$(VARIANT))
+CONTAINER := $(CONTAINER_NAME)$(if $(VARIANT),-$(VARIANT))
+CMD_SUFFIX := $(if $(VARIANT),-$(VARIANT))
+
 .DEFAULT_GOAL := help
 
 help: ## Show this help
@@ -16,20 +24,21 @@ brew: ## Install Homebrew packages
 	./scripts/install/brew.sh
 	./scripts/install/brew-cask.sh
 
-docker-build: ## Build Docker test image
-	docker build -t $(IMAGE_NAME) .
+docker-build: ## Build Docker image (use VARIANT=minimal for minimal)
+	docker build -f $(DOCKERFILE) -t $(IMAGE) .
 
-docker-shell: docker-build ## Start persistent shell in Docker (state preserved)
-	@docker start -ai $(CONTAINER_NAME) 2>/dev/null || docker run -it --name $(CONTAINER_NAME) $(IMAGE_NAME)
+docker-shell: docker-build ## Start persistent shell (use VARIANT=minimal for minimal)
+	@docker start -ai $(CONTAINER) 2>/dev/null || docker run -it --name $(CONTAINER) $(IMAGE) setup$(CMD_SUFFIX)
 
-docker-test: docker-build ## Run setup and validation in Docker
-	docker run --rm $(IMAGE_NAME) test
+docker-test: docker-build ## Run setup and validation (use VARIANT=minimal for minimal)
+	docker run --rm $(IMAGE) test$(CMD_SUFFIX)
 
-docker-setup: docker-build ## Run setup and drop into shell
-	docker run -it --rm $(IMAGE_NAME) setup
+docker-setup: docker-build ## Run setup and drop into shell (use VARIANT=minimal for minimal)
+	docker run -it --rm $(IMAGE) setup$(CMD_SUFFIX)
 
-docker-clean: ## Remove persistent Docker container
+docker-clean: ## Remove persistent Docker containers
 	docker rm -f $(CONTAINER_NAME) 2>/dev/null || true
+	docker rm -f $(CONTAINER_NAME)-minimal 2>/dev/null || true
 
 docker-test-remote: ## Smoke test remote install from deployed URL
 	docker build -f Dockerfile.remote-test -t $(IMAGE_NAME)-remote .
@@ -39,10 +48,4 @@ docker-test-remote-local: ## Test remote install using local HTTP server
 	docker build -f Dockerfile.remote-test -t $(IMAGE_NAME)-remote .
 	docker run --rm $(IMAGE_NAME)-remote remote-test-local
 
-docker-build-minimal: ## Build minimal Docker image (no Homebrew)
-	docker build -f Dockerfile.minimal -t $(IMAGE_NAME)-minimal .
-
-docker-test-minimal: docker-build-minimal ## Test setup without Homebrew
-	docker run --rm $(IMAGE_NAME)-minimal test
-
-.PHONY: help install uninstall brew docker-build docker-test docker-shell docker-setup docker-clean docker-test-remote docker-test-remote-local docker-build-minimal docker-test-minimal
+.PHONY: help install uninstall brew docker-build docker-test docker-shell docker-setup docker-clean docker-test-remote docker-test-remote-local

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,10 @@ docker-test-remote-local: ## Test remote install using local HTTP server
 	docker build -f Dockerfile.remote-test -t $(IMAGE_NAME)-remote .
 	docker run --rm $(IMAGE_NAME)-remote remote-test-local
 
-.PHONY: help install uninstall brew docker-build docker-test docker-shell docker-setup docker-clean docker-test-remote docker-test-remote-local
+docker-build-minimal: ## Build minimal Docker image (no Homebrew)
+	docker build -f Dockerfile.minimal -t $(IMAGE_NAME)-minimal .
+
+docker-test-minimal: docker-build-minimal ## Test setup without Homebrew
+	docker run --rm $(IMAGE_NAME)-minimal test
+
+.PHONY: help install uninstall brew docker-build docker-test docker-shell docker-setup docker-clean docker-test-remote docker-test-remote-local docker-build-minimal docker-test-minimal

--- a/README.md
+++ b/README.md
@@ -200,9 +200,26 @@ make docker-shell
 # Run setup and drop into shell
 make docker-setup
 
-# Clean up persistent container
+# Clean up persistent containers
 make docker-clean
 ```
+
+### Minimal Setup (No Homebrew/Bun)
+
+Test the fallback paths without Homebrew or Bun using the `VARIANT=minimal` flag:
+
+```bash
+# Run minimal setup and validation
+make docker-test VARIANT=minimal
+
+# Interactive shell with minimal setup (persistent state)
+make docker-shell VARIANT=minimal
+
+# Run minimal setup and drop into shell
+make docker-setup VARIANT=minimal
+```
+
+The minimal variant uses a bare Ubuntu image instead of the Homebrew base image, testing that the dotfiles install correctly when Homebrew and Bun are not available.
 
 ### Testing Remote Install
 
@@ -231,9 +248,11 @@ Run `make` to see all available commands:
 | `make docker-test`              | Run setup and validation in Docker        |
 | `make docker-setup`             | Run setup and drop into shell             |
 | `make docker-shell`             | Start persistent shell in Docker          |
-| `make docker-clean`             | Remove persistent Docker container        |
+| `make docker-clean`             | Remove persistent Docker containers       |
 | `make docker-test-remote`       | Smoke test remote install (deployed URL)  |
 | `make docker-test-remote-local` | Test remote install via local HTTP server |
+
+Docker commands support `VARIANT=minimal` for testing without Homebrew/Bun (e.g., `make docker-test VARIANT=minimal`).
 
 ## Claude Code Plugin
 

--- a/claude-plugin/.claude-plugin/marketplace.json
+++ b/claude-plugin/.claude-plugin/marketplace.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "tyom",
-  "description": "Personal development tools and workflow automation",
+  "metadata": {
+    "description": "Personal development tools and workflow automation"
+  },
   "owner": {
     "name": "tyom"
   },

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,23 +2,44 @@
 
 # Docker entrypoint for dotfiles testing
 # Usage:
-#   docker run <image>              # Interactive shell (no setup)
-#   docker run <image> setup        # Run setup, then shell
-#   docker run <image> validate     # Run validation only
-#   docker run <image> test         # Run setup + validation
+#   docker run <image>               # Interactive shell (no setup)
+#   docker run <image> setup         # Run setup, then shell
+#   docker run <image> setup-minimal # Run setup without Homebrew/Bun, then shell
+#   docker run <image> validate      # Run validation only
+#   docker run <image> test          # Run setup + validation
+#   docker run <image> test-minimal  # Run minimal setup + validation
 
 set -e
 
-DOTFILES_DIR="$HOME/dotfiles"
+DOTFILES_DIR="$HOME/.dotfiles"
 cd "$DOTFILES_DIR"
 
 case "${1:-shell}" in
 setup)
-  echo "Running dotfiles setup..."
-  export YES_OVERRIDE=true
-  ./scripts/setup.sh
-  echo ""
-  echo "Setup complete. Starting shell..."
+  if [ -f "$HOME/.dotfiles-setup-done" ]; then
+    echo "Setup already complete. Starting shell..."
+  else
+    echo "Running dotfiles setup..."
+    export YES_OVERRIDE=true
+    ./scripts/setup.sh
+    touch "$HOME/.dotfiles-setup-done"
+    echo ""
+    echo "Setup complete. Starting shell..."
+  fi
+  exec zsh
+  ;;
+setup-minimal)
+  if [ -f "$HOME/.dotfiles-setup-done" ]; then
+    echo "Setup already complete. Starting shell..."
+  else
+    echo "Running minimal dotfiles setup (no Homebrew/Bun)..."
+    export YES_OVERRIDE=true
+    export MINIMAL_SETUP=true
+    ./scripts/setup.sh
+    touch "$HOME/.dotfiles-setup-done"
+    echo ""
+    echo "Setup complete. Starting shell..."
+  fi
   exec zsh
   ;;
 validate)
@@ -28,6 +49,12 @@ validate)
 test)
   echo "Running setup (includes validation)..."
   export YES_OVERRIDE=true
+  ./scripts/setup.sh
+  ;;
+test-minimal)
+  echo "Running minimal setup (includes validation)..."
+  export YES_OVERRIDE=true
+  export MINIMAL_SETUP=true
   ./scripts/setup.sh
   ;;
 shell)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,12 +22,14 @@ fi
 
 # Install Bun via Homebrew (optional, for faster JS tooling)
 if command -v brew &>/dev/null; then
-  if ! command -v bun &>/dev/null; then
-    print_step 'Installing Bun'
-    brew install oven-sh/bun/bun
-  else
-    print_info 'Bun already installed'
-  fi
+  continue_or_skip 'Install Bun (faster JS tooling)?' 'y' && {
+    if ! command -v bun &>/dev/null; then
+      print_step 'Installing Bun'
+      brew install oven-sh/bun/bun
+    else
+      print_info 'Bun already installed'
+    fi
+  } || print_info 'Skipping Bun'
 fi
 
 # Install Volta (Node.js version manager)
@@ -85,12 +87,12 @@ if [ -f "$PLUGIN_DIR/package.json" ]; then
     # Register plugin if claude is available
     if command -v claude &>/dev/null; then
       print_step 'Registering Claude Code dotfiles plugin'
-      if claude plugin marketplace add "$PLUGIN_DIR" 2>&1; then
+      if claude plugin marketplace add "$PLUGIN_DIR" &>/dev/null; then
         print_success 'Plugin marketplace entry added'
       else
         print_info 'Plugin marketplace entry may already exist'
       fi
-      if claude plugin install dotfiles@tyom --scope user 2>&1; then
+      if claude plugin install dotfiles@tyom --scope user &>/dev/null; then
         print_success 'Plugin installed successfully'
       else
         print_info 'Plugin may already be installed'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -67,9 +67,17 @@ if [ -f "$PLUGIN_DIR/package.json" ]; then
     'Install Claude Code plugin?' 'y' && {
     print_step 'Installing Claude Code plugin dependencies'
     if command -v bun &>/dev/null; then
-      (cd "$PLUGIN_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
+      if (cd "$PLUGIN_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install); then
+        print_success 'Dependencies installed via bun'
+      else
+        print_error 'Failed to install dependencies via bun'
+      fi
     elif command -v npm &>/dev/null; then
-      (cd "$PLUGIN_DIR" && npm install)
+      if (cd "$PLUGIN_DIR" && npm install); then
+        print_success 'Dependencies installed via npm'
+      else
+        print_error 'Failed to install dependencies via npm'
+      fi
     else
       print_info 'Skipping: neither bun nor npm available'
     fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,9 +21,9 @@ if [ "$(which_os)" == "macos" ]; then
 fi
 
 # Install Bun (required for Claude Code plugin and JS tooling)
-if ! command -v bun &> /dev/null; then
+if ! command -v bun &>/dev/null; then
   print_step 'Installing Bun'
-  curl -fsSL https://bun.sh/install | bash
+  curl -fsSL https://bun.com/install | bash
   export BUN_INSTALL="$HOME/.bun"
   export PATH="$BUN_INSTALL/bin:$PATH"
 else
@@ -31,7 +31,7 @@ else
 fi
 
 # Install Volta (Node.js version manager)
-if ! command -v volta &> /dev/null; then
+if ! command -v volta &>/dev/null; then
   print_step 'Installing Volta'
   curl -fsSL https://get.volta.sh | bash -s -- --skip-setup
   export VOLTA_HOME="$HOME/.volta"
@@ -41,7 +41,7 @@ else
 fi
 
 # Install default Node.js via Volta
-if command -v volta &> /dev/null && ! volta which node &>/dev/null; then
+if command -v volta &>/dev/null && ! volta which node &>/dev/null; then
   print_step 'Installing Node.js via Volta'
   volta install node
 else
@@ -68,7 +68,7 @@ if [ -f "$PLUGIN_DIR/package.json" ]; then
 fi
 
 # Register Claude Code plugin if claude is available
-if command -v claude &> /dev/null; then
+if command -v claude &>/dev/null; then
   print_step 'Registering Claude Code dotfiles plugin'
   claude plugin marketplace add "$PLUGIN_DIR" 2>/dev/null || true
   claude plugin install dotfiles@tyom --scope user 2>/dev/null || true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -67,7 +67,7 @@ if [ -f "$PLUGIN_DIR/package.json" ]; then
     'Install Claude Code plugin?' 'y' && {
     print_step 'Installing Claude Code plugin dependencies'
     if command -v bun &>/dev/null; then
-      if (cd "$PLUGIN_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install); then
+      if (cd "$PLUGIN_DIR" && (bun install --frozen-lockfile || bun install)); then
         print_success 'Dependencies installed via bun'
       else
         print_error 'Failed to install dependencies via bun'
@@ -85,8 +85,16 @@ if [ -f "$PLUGIN_DIR/package.json" ]; then
     # Register plugin if claude is available
     if command -v claude &>/dev/null; then
       print_step 'Registering Claude Code dotfiles plugin'
-      claude plugin marketplace add "$PLUGIN_DIR" 2>/dev/null || true
-      claude plugin install dotfiles@tyom --scope user 2>/dev/null || true
+      if claude plugin marketplace add "$PLUGIN_DIR" 2>&1; then
+        print_success 'Plugin marketplace entry added'
+      else
+        print_info 'Plugin marketplace entry may already exist'
+      fi
+      if claude plugin install dotfiles@tyom --scope user 2>&1; then
+        print_success 'Plugin installed successfully'
+      else
+        print_info 'Plugin may already be installed'
+      fi
     fi
   } || print_info 'Skipping Claude Code plugin'
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,10 +8,14 @@ echo -e "Installing dotfiles for $(which_os)…"
 continue_or_exit \
   'This will install dotfiles for your system and update your .zshrc file.' 'y'
 
-continue_or_skip \
-  'Install Homebrew and useful packages? This may take a while.' 'y' &&
-  source "$DOTFILES_DIR/scripts/install/brew.sh" ||
-  print_info 'Skipping Homebrew'
+if [[ "${MINIMAL_SETUP:-}" == "true" ]]; then
+  print_info 'Skipping Homebrew (minimal setup)'
+else
+  continue_or_skip \
+    'Install Homebrew and useful packages? This may take a while.' 'y' &&
+    source "$DOTFILES_DIR/scripts/install/brew.sh" ||
+    print_info 'Skipping Homebrew'
+fi
 
 if [ "$(which_os)" == "macos" ]; then
   continue_or_skip \
@@ -20,12 +24,16 @@ if [ "$(which_os)" == "macos" ]; then
     print_info 'Skipping Brew Cask'
 fi
 
-# Install Bun via Homebrew (optional, for faster JS tooling)
-if command -v brew &>/dev/null; then
+# Install Bun (optional, for faster JS tooling)
+if [[ "${MINIMAL_SETUP:-}" == "true" ]]; then
+  print_info 'Skipping Bun (minimal setup)'
+else
   continue_or_skip 'Install Bun (faster JS tooling)?' 'y' && {
     if ! command -v bun &>/dev/null; then
       print_step 'Installing Bun'
-      brew install oven-sh/bun/bun
+      curl -fsSL https://bun.com/install | bash
+      export BUN_INSTALL="$HOME/.bun"
+      export PATH="$BUN_INSTALL/bin:$PATH"
     else
       print_info 'Bun already installed'
     fi

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -228,9 +228,17 @@ if [ -d "$PLUGIN_DIR" ] && [ -f "$PLUGIN_DIR/package.json" ]; then
   if [ ! -d "$PLUGIN_DIR/node_modules" ]; then
     print_info "Installing plugin dependencies..."
     if command -v bun >/dev/null 2>&1; then
-      (cd "$PLUGIN_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
+      if (cd "$PLUGIN_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install); then
+        print_success "Dependencies installed with bun"
+      else
+        print_error "Failed to install dependencies with bun"
+      fi
     elif command -v npm >/dev/null 2>&1; then
-      (cd "$PLUGIN_DIR" && npm install)
+      if (cd "$PLUGIN_DIR" && npm install); then
+        print_success "Dependencies installed with npm"
+      else
+        print_error "Failed to install dependencies with npm"
+      fi
     else
       print_skip "Neither bun nor npm available, skipping plugin check"
     fi

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -244,9 +244,6 @@ if [ -d "$PLUGIN_DIR" ] && [ -f "$PLUGIN_DIR/package.json" ]; then
         print_error "Failed to install dependencies with npm"
       fi
     fi
-    if [ "$INSTALL_SUCCESS" = false ]; then
-      print_skip "Neither bun nor npm available, skipping plugin check"
-    fi
   fi
   # Type check the plugin if dependencies are installed
   if [ -d "$PLUGIN_DIR/node_modules" ]; then

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -117,15 +117,15 @@ if command -v fzf >/dev/null 2>&1; then
     ERRORS=$((ERRORS + 1))
   fi
 else
-  print_info "fzf not installed, skipping FZF_BASE check"
+  print_skip "fzf not installed, skipping FZF_BASE check"
 fi
 
-# Check if our PATH modifications are loaded
-DOTFILES_BIN_CHECK=$(zsh -c 'source ~/.zshrc 2>/dev/null; echo $PATH' | grep -c "$DOTFILES_DIR/bin")
-if [ "$DOTFILES_BIN_CHECK" -gt 0 ]; then
-  print_success "DOTFILES_DIR/bin is in PATH"
+# Check if ~/bin is in PATH (where stow symlinks bin scripts)
+HOME_BIN_CHECK=$(zsh -c 'source ~/.zshrc 2>/dev/null; echo $PATH' | grep -c "$HOME/bin" || true)
+if [ "$HOME_BIN_CHECK" -gt 0 ]; then
+  print_success "~/bin is in PATH"
 else
-  print_error "DOTFILES_DIR/bin not in PATH"
+  print_error "~/bin not in PATH"
   ERRORS=$((ERRORS + 1))
 fi
 
@@ -151,8 +151,7 @@ if command -v fzf >/dev/null 2>&1; then
     ERRORS=$((ERRORS + 1))
   fi
 else
-  echo ""
-  print_info "fzf not installed, skipping fzf check"
+  print_skip "fzf not installed, skipping fzf check"
 fi
 
 # Check bin scripts
@@ -180,8 +179,8 @@ done
 echo ""
 print_info "Checking git configuration..."
 
-if git config --global --get alias.s >/dev/null 2>&1; then
-  print_success "Git aliases configured"
+if git config --global --includes --get alias.s >/dev/null 2>&1; then
+  print_success "Git aliases loaded"
 else
   print_error "Git aliases not loaded"
   ERRORS=$((ERRORS + 1))
@@ -201,7 +200,7 @@ print_info "Checking JS tooling..."
 if command -v bun >/dev/null 2>&1; then
   print_success "Bun is installed ($(bun --version))"
 else
-  print_info "Bun not installed (optional, install via Homebrew)"
+  print_skip "Bun not installed (optional)"
 fi
 
 if command -v volta >/dev/null 2>&1; then
@@ -233,7 +232,7 @@ if [ -d "$PLUGIN_DIR" ] && [ -f "$PLUGIN_DIR/package.json" ]; then
     elif command -v npm >/dev/null 2>&1; then
       (cd "$PLUGIN_DIR" && npm install)
     else
-      print_info "Neither bun nor npm available, skipping plugin check"
+      print_skip "Neither bun nor npm available, skipping plugin check"
     fi
   fi
   # Type check the plugin if dependencies are installed
@@ -255,7 +254,7 @@ if [ -d "$PLUGIN_DIR" ] && [ -f "$PLUGIN_DIR/package.json" ]; then
     fi
   fi
 else
-  print_info "Claude Code plugin not found, skipping"
+  print_skip "Claude Code plugin not found, skipping"
 fi
 
 # Check Homebrew packages (optional - warnings only)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -227,19 +227,24 @@ if [ -d "$PLUGIN_DIR" ] && [ -f "$PLUGIN_DIR/package.json" ]; then
   # Install dependencies if needed
   if [ ! -d "$PLUGIN_DIR/node_modules" ]; then
     print_info "Installing plugin dependencies..."
+    INSTALL_SUCCESS=false
     if command -v bun >/dev/null 2>&1; then
       if (cd "$PLUGIN_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install); then
         print_success "Dependencies installed with bun"
+        INSTALL_SUCCESS=true
       else
         print_error "Failed to install dependencies with bun"
       fi
-    elif command -v npm >/dev/null 2>&1; then
+    fi
+    if [ "$INSTALL_SUCCESS" = false ] && command -v npm >/dev/null 2>&1; then
       if (cd "$PLUGIN_DIR" && npm install); then
         print_success "Dependencies installed with npm"
+        INSTALL_SUCCESS=true
       else
         print_error "Failed to install dependencies with npm"
       fi
-    else
+    fi
+    if [ "$INSTALL_SUCCESS" = false ]; then
       print_skip "Neither bun nor npm available, skipping plugin check"
     fi
   fi
@@ -259,6 +264,8 @@ if [ -d "$PLUGIN_DIR" ] && [ -f "$PLUGIN_DIR/package.json" ]; then
         print_error "Claude Code plugin type check failed"
         ERRORS=$((ERRORS + 1))
       fi
+    else
+      print_skip "No type checker available (bun/npx required)"
     fi
   fi
 else

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -123,9 +123,9 @@ fi
 # Check if ~/bin is in PATH (where stow symlinks bin scripts)
 HOME_BIN_CHECK=$(zsh -c 'source ~/.zshrc 2>/dev/null; echo $PATH' | grep -c "$HOME/bin" || true)
 if [ "$HOME_BIN_CHECK" -gt 0 ]; then
-  print_success "~/bin is in PATH"
+  print_success "$HOME/bin is in PATH"
 else
-  print_error "~/bin not in PATH"
+  print_error "$HOME/bin not in PATH"
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -143,8 +143,8 @@ if command -v fzf >/dev/null 2>&1; then
   echo ""
   print_info "Checking fzf configuration..."
 
-  if grep -q "plugins.*fzf" "$DOTFILES_DIR/zsh/config.zsh" 2>/dev/null || \
-     grep -q 'plugins+=(fzf)' "$DOTFILES_DIR/zsh/config.zsh" 2>/dev/null; then
+  if grep -q "plugins.*fzf" "$DOTFILES_DIR/zsh/config.zsh" 2>/dev/null ||
+    grep -q 'plugins+=(fzf)' "$DOTFILES_DIR/zsh/config.zsh" 2>/dev/null; then
     print_success "fzf plugin configured"
   else
     print_error "fzf plugin not configured in zsh/config.zsh"
@@ -202,7 +202,7 @@ if command -v bun >/dev/null 2>&1; then
   print_success "Bun is installed ($(bun --version))"
 else
   print_error "Bun is not installed"
-  print_info "Install with: curl -fsSL https://bun.sh/install | bash"
+  print_info "Install with: curl -fsSL https://bun.com/install | bash"
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/scripts/zsh.sh
+++ b/scripts/zsh.sh
@@ -29,7 +29,8 @@ fi
 if [[ ! -d $HOME/.oh-my-zsh/ ]]; then
   # RUNZSH=no: Don't start zsh after install
   # KEEP_ZSHRC=yes: Don't overwrite .zshrc
-  RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+  # CHSH=no: Don't prompt to change shell (user can do this manually)
+  RUNZSH=no KEEP_ZSHRC=yes CHSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 else
   print_info 'oh-my-zsh is already installed. Skipping.'
 fi

--- a/shell/utils.sh
+++ b/shell/utils.sh
@@ -109,6 +109,10 @@ function print_info {
   printf "\e[0;35m » $1\e[0m\n"
 }
 
+function print_skip {
+  printf "\e[0;33m ○ $1\e[0m\n"
+}
+
 function print_success {
   printf "\e[0;32m ✔ $1\e[0m\n"
 }


### PR DESCRIPTION
## Summary

- Add minimal Docker test environment (Dockerfile.minimal) for testing without Homebrew/Bun
- Make Bun installation optional with npm fallback for Claude plugin
- Use `bun.com/install` instead of `bun.sh/install` (some security scripts may be triggered with bun.sh due to previous incident with supply chain attack)
- Add VARIANT=minimal flag to Makefile for easy minimal image testing
- Add CI workflow for testing minimal setup path
- Fix Claude plugin marketplace schema structure
- Improve validation script with print_skip function and npm fallback

## Changes

###  Docker & Testing Infrastructure
  - New Dockerfile.minimal using bare Ubuntu 24.04 (no Homebrew)
  - Makefile now supports VARIANT=minimal flag for all docker commands
  - Docker entrypoint supports setup-minimal and test-minimal commands
  - Added GitHub Actions job minimal-test to CI workflow
  - Changed dotfiles path from ~/dotfiles to ~/.dotfiles in Docker

###  Setup Script Improvements
  - Bun is now optional with a prompt (was required)
  - Updated Bun install URL from bun.sh to bun.com
  - Claude plugin dependencies can use npm as fallback when Bun unavailable
  - Added MINIMAL_SETUP=true env var to skip Homebrew/Bun
  - Added success/error feedback for dependency installation outcomes
  - Made Claude plugin installation opt-in with prompt

###  Validation Script
  - Added print_skip function for clearer output on skipped checks
  - Bun is no longer required (skip instead of error)
  - npm/npx fallback for plugin type checking
  - Fixed git alias check to use --includes flag
  - Changed PATH check from $DOTFILES_DIR/bin to ~/bin

###  Other Fixes
  - Fixed marketplace.json schema (moved description under metadata)
  - Added CHSH=no to oh-my-zsh install to skip shell change prompt
  - Suppressed Claude plugin command output during setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Minimal setup mode for environments without Homebrew/Bun, with optional Bun and plugin prompts and graceful skips.

* **Refactor**
  * Dotfiles path and entrypoint updated to support idempotent setup and new setup/test minimal variants.

* **Bug Fixes**
  * Installer made non-interactive (no shell-change prompts) and skip messages improved for optional tooling.

* **Documentation**
  * Added VARIANT=minimal examples and expanded remote-install testing notes.

* **Chores / CI**
  * Added minimal CI job and VARIANT-driven Make targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->