### PR TITLE
Add environment variable toggles to disable hooks per-project

### DIFF
--- a/claude-plugin/hooks/README.md
+++ b/claude-plugin/hooks/README.md
@@ -1,0 +1,45 @@
+# Hooks
+
+Claude Code hooks that run automatically during various events.
+
+## Available Hooks
+
+### PostToolUse: Lint and Typecheck
+
+**Trigger:** After `Edit`, `MultiEdit`, or `Write` operations on supported files.
+
+**Actions:**
+
+- TypeScript type checking (if tsconfig.json present)
+- Prettier formatting (auto-fixes if needed)
+- ESLint linting
+
+**Supported file extensions:** `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.mts`, `.md`, `.mdx`, `.json`, `.yaml`, `.yml`, `.css`, `.scss`, `.html`
+
+### Stop: Run Tests
+
+**Trigger:** Before Claude stops working.
+
+**Actions:**
+
+- Detects test runner (bun, npm, yarn, pnpm, vitest, jest, mocha)
+- Runs project tests
+- Blocks stopping if tests fail
+
+## Configuration
+
+Both hooks can be disabled per-project using environment variables in `.claude/settings.local.json`:
+
+```json
+{
+  "env": {
+    "LINT_ON_SAVE": "false",
+    "RUN_TESTS_ON_STOP": "false"
+  }
+}
+```
+
+| Variable            | Default | Description                                             |
+| ------------------- | ------- | ------------------------------------------------------- |
+| `LINT_ON_SAVE`      | `true`  | Enable/disable lint, typecheck, and format on file save |
+| `RUN_TESTS_ON_STOP` | `true`  | Enable/disable running tests before stopping            |

--- a/claude-plugin/hooks/post-tool-use/lint-and-typecheck.ts
+++ b/claude-plugin/hooks/post-tool-use/lint-and-typecheck.ts
@@ -130,12 +130,19 @@ function runCommand(
  * Aggregates tool outputs as errors or warnings. Prints errors to stderr and exits with code 2;
  * prints warnings to stdout and exits with code 0 on success or when no action was necessary.
  *
+ * Can be disabled by setting LINT_ON_SAVE=false environment variable.
+ *
  * @remarks
  * Exit codes:
  * - 0: success or no applicable action
  * - 2: blocking errors detected (TypeScript, Prettier, or ESLint)
  */
 async function main() {
+  // Check if linting is disabled via environment variable (default: enabled)
+  if (process.env.LINT_ON_SAVE === "false") {
+    process.exit(0);
+  }
+
   let input: ToolInput;
 
   try {

--- a/claude-plugin/hooks/stop/run-tests.ts
+++ b/claude-plugin/hooks/stop/run-tests.ts
@@ -225,8 +225,15 @@ async function findProjectRoot(): Promise<string> {
  * Reads JSON input from stdin to detect an active stop hook; if present, allows stopping immediately.
  * Locates the project root and detects an appropriate test runner; if no runner is found or no test files exist, allows stopping.
  * Executes the detected test suite; if tests fail, writes a JSON decision object to stdout with `decision: "block"` and a `reason` that includes the test output, then exits.
+ *
+ * Can be disabled by setting RUN_TESTS_ON_STOP=false environment variable.
  */
 async function main() {
+  // Check if tests on stop are disabled via environment variable (default: enabled)
+  if (process.env.RUN_TESTS_ON_STOP === "false") {
+    process.exit(0);
+  }
+
   let input: StopHookInput = {};
 
   try {


### PR DESCRIPTION
Hooks can now be disabled via `LINT_ON_SAVE` and `RUN_TESTS_ON_STOP` environment variables (both default to true). Set to `"false"` in `.claude/settings.local.json` to skip hooks for specific projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable Hooks feature enabling automatic linting, type checking and test execution.
  * Added per-project configuration support via environment variables for customising behaviour.

* **Documentation**
  * Added comprehensive Hooks feature guide outlining available hooks, trigger conditions and configuration instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->