### PR TITLE
Add visual status line for Claude Code

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -6,6 +6,8 @@ Personal development workflow automation - hooks, tools, and configurations.
 
 A custom status bar showing model name and context usage with a visual progress bar.
 
+Requires: `jq`
+
 ### Enable
 
 Add to `~/.claude/settings.json`:

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -29,5 +29,5 @@ Opus 4.5 | ctx ■■■■■□□□□□□□□□□□□□□□ 25%
 Colors change based on usage:
 
 - Grey: < 60%
-- Orange: 60-80%
-- Red: > 80%
+- Orange: 60–79%
+- Red: ≥ 80%

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,33 @@
+# Claude Code Dotfiles Plugin
+
+Personal development workflow automation - hooks, tools, and configurations.
+
+## Status Line
+
+A custom status bar showing model name and context usage with a visual progress bar.
+
+### Enable
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/Code/dotfiles/claude-plugin/statusline/statusline.sh",
+    "padding": 0
+  }
+}
+```
+
+### Output
+
+```
+Opus 4.5 | ctx ■■■■■□□□□□□□□□□□□□□□ 25%
+```
+
+Colors change based on usage:
+
+- Grey: < 60%
+- Orange: 60-80%
+- Red: > 80%

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -22,12 +22,14 @@ Add to `~/.claude/settings.json`:
 
 ### Output
 
-```
-Opus 4.5 | ctx ■■■■■□□□□□□□□□□□□□□□ 25%
+```text
+Opus 4.5 | ctx ■■■■■□□□□□□□□□□▨▨▨▨▨ 33%
 ```
 
-Colors change based on usage:
+The bar shows 15 usable squares plus 5 reserved squares (▨) representing the 22.5% auto-compact buffer. The percentage shown is the **effective usage** against the usable 77.5% of context (e.g., 25% total context = 32% effective).
 
-- Grey: < 60%
-- Orange: 60–79%
-- Red: ≥ 80%
+Colors change based on effective usage:
+
+- Grey: < 75% (~58% total)
+- Orange: 75–93% (~58–72% total)
+- Red: ≥ 94% (~73%+ total)

--- a/claude-plugin/statusline/statusline.sh
+++ b/claude-plugin/statusline/statusline.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Requires: jq
+if ! command -v jq &>/dev/null; then
+  echo "statusline: jq required" >&2
+  exit 1
+fi
+
 # Read JSON input from stdin
 input=$(cat)
 

--- a/claude-plugin/statusline/statusline.sh
+++ b/claude-plugin/statusline/statusline.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract context stats using jq
+USED_TOKENS=$(echo "$input" | jq -r '(.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)')
+USED_PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0')
+
+# Calculate total context window from percentage
+if (( $(echo "$USED_PCT > 0" | bc -l) )); then
+  MAX_TOKENS=$(echo "scale=0; $USED_TOKENS * 100 / $USED_PCT" | bc)
+else
+  MAX_TOKENS=0
+fi
+
+# Format token counts (e.g., 15234 -> 15.2k)
+format_tokens() {
+  local tokens=$1
+  if [ "$tokens" -ge 1000 ]; then
+    echo "$(echo "scale=1; $tokens / 1000" | bc)k"
+  else
+    echo "$tokens"
+  fi
+}
+
+USED_FMT=$(format_tokens "$USED_TOKENS")
+MAX_FMT=$(format_tokens "$MAX_TOKENS")
+
+# Color based on usage (green < 50%, yellow 50-75%, red > 75%)
+if (( $(echo "$USED_PCT < 50" | bc -l) )); then
+  COLOR="\033[32m"  # Green
+elif (( $(echo "$USED_PCT < 75" | bc -l) )); then
+  COLOR="\033[33m"  # Yellow
+else
+  COLOR="\033[31m"  # Red
+fi
+RESET="\033[0m"
+
+# Output: 68.4k/200k tokens (20%)
+printf "%s/%s tokens ${COLOR}(%.0f%%)${RESET}" "$USED_FMT" "$MAX_FMT" "$USED_PCT"

--- a/claude-plugin/statusline/statusline.sh
+++ b/claude-plugin/statusline/statusline.sh
@@ -11,24 +11,32 @@ if (( $(echo "$USED_PCT == 0" | bc -l) )); then
   exit 0
 fi
 
-# Clamp percentage to 0-100 range
-CLAMPED_PCT=$(echo "if ($USED_PCT < 0) 0 else if ($USED_PCT > 100) 100 else $USED_PCT" | bc -l)
+# Auto-compact threshold is 77.5% (22.5% buffer)
+# Calculate effective percentage against the 77.5% threshold
+EFFECTIVE_PCT=$(echo "scale=2; $USED_PCT / 77.5 * 100" | bc -l)
+if (( $(echo "$EFFECTIVE_PCT > 100" | bc -l) )); then
+  EFFECTIVE_PCT=100
+fi
 
-# Build progress bar (20 squares total, each full = 5%, half = 2.5%)
+# Clamp raw percentage to 0-77.5 range (usable portion)
+CLAMPED_PCT=$(echo "if ($USED_PCT < 0) 0 else if ($USED_PCT > 77.5) 77.5 else $USED_PCT" | bc -l)
+
+# Build progress bar: 15 usable squares (75%) + 5 reserved squares (25%)
+# Each square = 5% of total context
 FULL_SQUARES=$(echo "scale=0; $CLAMPED_PCT / 5" | bc)
-if [ "$FULL_SQUARES" -gt 20 ]; then
-  FULL_SQUARES=20
+if [ "$FULL_SQUARES" -gt 15 ]; then
+  FULL_SQUARES=15
 fi
 
 REMAINDER=$(echo "scale=1; $CLAMPED_PCT - ($FULL_SQUARES * 5)" | bc)
-if [ "$FULL_SQUARES" -lt 20 ] && (( $(echo "$REMAINDER >= 2.5" | bc -l) )); then
+if [ "$FULL_SQUARES" -lt 15 ] && (( $(echo "$REMAINDER >= 2.5" | bc -l) )); then
   HAS_HALF=1
 else
   HAS_HALF=0
 fi
 
 HALF_COUNT=$((HAS_HALF))
-EMPTY_SQUARES=$((20 - FULL_SQUARES - HALF_COUNT))
+EMPTY_SQUARES=$((15 - FULL_SQUARES - HALF_COUNT))
 if [ "$EMPTY_SQUARES" -lt 0 ]; then
   EMPTY_SQUARES=0
 fi
@@ -44,15 +52,17 @@ for ((i=0; i<EMPTY_SQUARES; i++)); do
   BAR+="□"
 done
 
-# Color based on usage (grey < 60%, orange 60-80%, red > 80%)
-if (( $(echo "$USED_PCT < 60" | bc -l) )); then
+# Color based on effective usage (grey < 75%, orange 75-94%, red >= 94%)
+# These thresholds correspond to 60%/75%/80% of total context
+if (( $(echo "$EFFECTIVE_PCT < 75" | bc -l) )); then
   COLOR="\033[90m"  # Grey
-elif (( $(echo "$USED_PCT < 80" | bc -l) )); then
-  COLOR="\033[38;5;208m"  # Orange
+elif (( $(echo "$EFFECTIVE_PCT < 94" | bc -l) )); then
+  COLOR="\033[38;5;208m"  # Orange (75% effective = 60% total)
 else
-  COLOR="\033[31m"  # Red
+  COLOR="\033[31m"  # Red (94% effective ≈ 75% total, near limit)
 fi
 RESET="\033[0m"
+DARK_GRAY="\033[38;5;240m"  # Dark gray for reserved blocks
 
-# Output: opus 4.5 | context: ■■■■■■◧□□□□□□□□□□□□□ 62%
-printf "%s | ctx ${COLOR}%s %.0f%%${RESET}" "$MODEL" "$BAR" "$USED_PCT"
+# Output: Opus 4.5 | ctx ■■■■■■■■■■■■■■□▨▨▨▨▨ 89%
+printf "%s | ctx ${COLOR}%s${DARK_GRAY}▨▨▨▨▨${COLOR} %.0f%%${RESET}" "$MODEL" "$BAR" "$EFFECTIVE_PCT"


### PR DESCRIPTION
Added status line bash script and updated the docs on how to install it.

<img width="2196" height="194" alt="image" src="https://github.com/user-attachments/assets/f27897ce-fd56-40f4-a80e-df1e8c55adf0" />
<img width="2198" height="206" alt="image" src="https://github.com/user-attachments/assets/bd63e285-499c-47bd-9084-159bcb9518c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status Line plugin shows model name and context-window usage as a 20-block visual bar (15 active + 5 reserved), with scaled percentage and colour-coded status (Grey <75%, Orange 75–93%, Red ≥94%).

* **Documentation**
  * Added README with setup instructions, configuration examples and sample output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->